### PR TITLE
65-track-limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ local.settings.json
 # Project specific files
 .cache
 .secrets
+config.staging.json

--- a/playlistbuilder.py
+++ b/playlistbuilder.py
@@ -84,8 +84,11 @@ class PlaylistGenerator:
         Check if this is running in the cloud, if not try to load a config file locally.
         """
         if local:
-            with open("config.staging.json", "r") as f:
-                self.config = json.load(f)
+            try:
+                with open("config.staging.json", "r") as f:
+                    self.config = json.load(f)
+            except FileNotFoundError:
+                self.config = {}
             return
         playlist = self.spotipy.playlist(self.get_playlist("name", self.plname))
         # Spotify escapes slashes, so we need to fix that

--- a/playlistbuilder.py
+++ b/playlistbuilder.py
@@ -337,9 +337,12 @@ class PlaylistGenerator:
                 pass
 
         try:
+            # spotify API says you can add a maximum of 100 tracks per request
+            # limit to 99 as we're not sure wether it's inclusive or not
             self.spotipy.user_playlist_replace_tracks(
-                self.spotipy.me()["id"], dailylistenid, tracks=sortedplaylist
+                self.spotipy.me()["id"], dailylistenid, tracks=sortedplaylist[:99]
             )
+
         except spotipy.exceptions.SpotifyException as err:
             str_err = str(err)
             if "429" in str_err and "500" in str_err:
@@ -362,7 +365,7 @@ class PlaylistGenerator:
                         DailyListen = self.spotipy.next(DailyListen)
                     else:
                         DailyListen = None
-                # Write to target playlost
+                # Write to target playlist
                 self.spotipy.playlist_add_items(dailylistenid, items=sortedplaylist)
 
 


### PR DESCRIPTION
Created a limit in how many tracks are pushed out at once.
Also updated the local config handling for testing purposes. 